### PR TITLE
Add joinMission action

### DIFF
--- a/src/components/Mission.jsx
+++ b/src/components/Mission.jsx
@@ -1,27 +1,51 @@
 import PropTypes from 'prop-types';
+import { useDispatch } from 'react-redux';
+import { joinMission } from '../redux/missions/missionsSlice';
 
-const Mission = (props) => {
-  const {
-    id, name, description,
-  } = props;
+const Mission = ({ mission }) => {
+  const dispatch = useDispatch();
+
+  const joinMissionHandler = (id) => {
+    dispatch(joinMission(id));
+  };
+
   return (
-    <tr key={id}>
-      <td>{name}</td>
-      <td>{description}</td>
+    <tr>
+      <td>{mission.mission_name}</td>
+      <td>{mission.description}</td>
       <td>
-        <button type="button">NOT A MEMBER</button>
+        {mission.reserved === true ? (
+          <button type="button">Active Member</button>
+        ) : (
+          <button type="button">Not a Member</button>
+        )}
       </td>
       <td>
-        <button type="button">Join Mission</button>
+        <button
+          className="btn btn-outline-secondary btn-sm"
+          type="button"
+          onClick={() => joinMissionHandler(mission.mission_id)}
+        >
+          Join Mission
+        </button>
       </td>
     </tr>
   );
 };
 
 Mission.propTypes = {
-  id: PropTypes.string.isRequired,
-  name: PropTypes.string.isRequired,
-  description: PropTypes.string.isRequired,
+  mission: PropTypes.shape({
+    mission_id: PropTypes.string.isRequired,
+    mission_name: PropTypes.string.isRequired,
+    description: PropTypes.string.isRequired,
+    reserved: PropTypes.bool,
+  }),
+};
+
+Mission.defaultProps = {
+  mission: {
+    reserved: false,
+  },
 };
 
 export default Mission;

--- a/src/components/MissionsContainer.jsx
+++ b/src/components/MissionsContainer.jsx
@@ -7,11 +7,11 @@ const MissionsContainer = () => {
   const dispatch = useDispatch();
   const ifSucceed = useSelector((store) => store.missions.ifSucceed);
   const isLoading = useSelector((store) => store.missions.isLoading);
-  const missions = useSelector((store) => store.missions.missions);
+  const missionsArray = useSelector((state) => state.missions.missionsArray);
 
   useEffect(() => {
     dispatch(fetchMissions());
-  }, [ifSucceed, dispatch]);
+  }, [dispatch, ifSucceed]);
 
   let content;
   if (isLoading) {
@@ -21,35 +21,27 @@ const MissionsContainer = () => {
       </tr>
     );
   } else if (ifSucceed) {
-    content = missions.map((mission) => (
-      <Mission
-        key={mission.mission_id}
-        id={mission.mission_id}
-        name={mission.mission_name}
-        description={mission.description}
-        status={mission.status}
-      />
+    content = missionsArray.map((mission) => (
+      <Mission key={mission.mission_id} mission={mission} />
     ));
   } else {
-    content = (
-      <tr>
-        <td>Something went wrong...</td>
-      </tr>
-    );
+    content = <tr><td>Something went wrong...</td></tr>;
   }
 
   return (
-    <table className="table table-striped table-bordered">
-      <thead>
-        <tr>
-          <th>Mission</th>
-          <th>Description</th>
-          <th>Status</th>
-          <th> </th>
-        </tr>
-      </thead>
-      <tbody>{content}</tbody>
-    </table>
+    <div className="container">
+      <table className="table table-striped table-bordered">
+        <thead>
+          <tr>
+            <th className="w-10">Mission</th>
+            <th className="w-50">Description</th>
+            <th className="w-20">Status</th>
+            <th className="w-20"> </th>
+          </tr>
+        </thead>
+        <tbody>{content}</tbody>
+      </table>
+    </div>
   );
 };
 

--- a/src/redux/missions/missionsSlice.jsx
+++ b/src/redux/missions/missionsSlice.jsx
@@ -4,7 +4,7 @@ import axios from 'axios';
 const MISSIONS_URL = 'https://api.spacexdata.com/v3/missions';
 
 const initialState = {
-  missions: [],
+  missionsArray: [],
   ifSucceed: false,
   isLoading: false,
   errors: null,
@@ -22,7 +22,17 @@ const fetchMissions = createAsyncThunk('missions/fetchMissions', async () => {
 const missionsSlice = createSlice({
   name: 'missions',
   initialState,
-  reducers: {},
+  reducers: {
+    joinMission: (state, action) => {
+      const newMissionsArray = state.missionsArray.map((mission) => {
+        if (mission.mission_id === action.payload) {
+          return { ...mission, reserved: true };
+        }
+        return mission;
+      });
+      return { ...state, missionsArray: newMissionsArray };
+    },
+  },
   extraReducers: (builder) => {
     builder
       .addCase(fetchMissions.pending, (state) => ({
@@ -33,7 +43,7 @@ const missionsSlice = createSlice({
         ...state,
         isLoading: false,
         ifSucceed: true,
-        missions: action.payload,
+        missionsArray: action.payload,
       }))
       .addCase(fetchMissions.rejected, (state) => ({
         ...state,
@@ -41,6 +51,8 @@ const missionsSlice = createSlice({
       }));
   },
 });
+
+export const { joinMission } = missionsSlice.actions;
 
 export { fetchMissions };
 


### PR DESCRIPTION
The following requests were completed in this pull request:

- When a user clicks the "Join Mission" button, action needs to be dispatched to update the store. You need to get the ID of the selected mission and update the state. Remember you mustn't mutate the state. Instead, you need to return a new state object with all missions, but the selected mission will have an extra key reserved with its value set to true. You could use a JS filter() or map() to set the value of the new state - i.e.:
const newState = state.map(rocket => {
    if(mission.id !== id) 
        return mission;
    return { ...mission, reserved: true };
});
- Regardless of which method you choose, make sure you place all your logic in the reducer. In the React view file, you should only dispatch the action with the correct rocket ID as an argument.